### PR TITLE
Gpio refactor

### DIFF
--- a/mqttany/modules/gpio.py
+++ b/mqttany/modules/gpio.py
@@ -290,7 +290,8 @@ def set_pin(pin, payload, **kwargs):
         return
 
     gpio.output(pin, state ^ pins[pin][CONF_KEY_INVERT])
-    log.debug("Set GPIO{pin} to '{payload}' logic {state}".format(pin=pin, state=TEXT_LOGIC_STATE[int(state)]))
+    log.debug("Set GPIO{pin} to '{payload}' logic {state}".format(
+        pin=pin, payload=payload, state=TEXT_LOGIC_STATE[int(state)]))
     get_pin(pin) # publish pin state
 
 

--- a/mqttany/modules/gpio.py
+++ b/mqttany/modules/gpio.py
@@ -247,7 +247,7 @@ def callback_setter(client, userdata, message):
     """
     queue.put_nowait({
         "func": "_callback_setter",
-        "args": [message.topic, message.payload]
+        "args": [message.topic, message.payload.decode("utf-8")]
     })
 
 def _callback_setter(topic, payload):

--- a/mqttany/modules/gpio.py
+++ b/mqttany/modules/gpio.py
@@ -127,7 +127,7 @@ def init(config_data={}):
                     pins[pin][CONF_KEY_TOPIC],
                     subtopics=["{module_topic}"],
                     substitutions={
-                        "module_topic": config[CONF_KEY_TOPIC],
+                        "module_topic": raw_config[CONF_KEY_TOPIC],
                         "module_name": TEXT_NAME,
                         "pin": pin
                     }

--- a/mqttany/modules/gpio.py
+++ b/mqttany/modules/gpio.py
@@ -75,6 +75,7 @@ CONF_OPTIONS_PIN = {
     CONF_KEY_INITIAL: {"default": "{payload_off}"},
 }
 
+TEXT_NAME = __name__.split(".")[-1]
 TEXT_DIRECTION = {GPIO.IN: "input", GPIO.OUT: "output"}
 TEXT_RESISTOR = {GPIO.PUD_UP: "up", GPIO.PUD_DOWN: "down", GPIO.PUD_OFF: "off"}
 TEXT_LOGIC_STATE = ["LOW", "HIGH"]
@@ -139,7 +140,7 @@ def loop():
                 pin=pin, direction=TEXT_DIRECTION[pins[pin][CONF_KEY_DIRECTION]]))
         log.debug("  with options [{options}]".format(options=pins[pin]))
 
-        if not acquire_gpio_lock(pin, __name__, timeout=2000):
+        if not acquire_gpio_lock(pin, TEXT_NAME, timeout=2000):
             log.error("Failed to acquire a lock on GPIO{pin}".format(pin=pin))
             pins.pop(pin)
             continue
@@ -163,7 +164,7 @@ def loop():
                     subtopics=["{module_topic}"],
                     substitutions={
                         "module_topic": config[CONF_KEY_TOPIC],
-                        "module_name": __name__,
+                        "module_name": TEXT_NAME,
                         "setter":config[CONF_KEY_TOPIC_SETTER],
                         "pin": pin
                     }
@@ -178,7 +179,7 @@ def loop():
                 subtopics=["{module_topic}"],
                 substitutions={
                     "module_topic": config[CONF_KEY_TOPIC],
-                    "module_name": __name__,
+                    "module_name": TEXT_NAME,
                     "getter":config[CONF_KEY_TOPIC_GETTER]
                 }
             )
@@ -190,7 +191,7 @@ def loop():
             subtopics=["{module_topic}"],
             substitutions={
                 "module_topic": config[CONF_KEY_TOPIC],
-                "module_name": __name__,
+                "module_name": TEXT_NAME,
             }
         )
 
@@ -228,7 +229,7 @@ def loop():
 
     gpio.cleanup()
     for pin in pins:
-        release_gpio_lock(pin, __name__)
+        release_gpio_lock(pin, TEXT_NAME)
 
 
 def interrupt_handler(pin):
@@ -268,7 +269,7 @@ def get_pin(pin, **kwargs):
             subtopics=["{module_topic}"],
             substitutions={
                 "module_topic": config[CONF_KEY_TOPIC],
-                "module_name": __name__,
+                "module_name": TEXT_NAME,
                 "pin": pin
             }
         )


### PR DESCRIPTION
* Add `initial state` option. Fixes #5 
* Rewrite message callbacks to streamline them
* Fix `set` payload as `bytes` not matching `str` `payload on`/`payload off`. This and commit [11a91d0](https://github.com/CrazyIvan359/mqttany/commit/11a91d078da2d596a87522ae7b10f8cf6a89af0d) Fixes #6 
* Misc fixes