### PR TITLE
Add config file version key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ automation setup much in order to interface with this version of MQTTany.
   * Python version check before importing anything with a minimum version requirement.
   * Import checking for the core requirements with log entries for missing packages.
   * Template modules and documentation to help with creating new modules.
+  * Config file version key. This will prevent MQTTany from running with an outdated
+    config file that may cause errors or strange behavior. Config version number will
+    incriment when incompatible changes occur in the config format.
 
 * **Changed**
   * Convert all string formatting to use *f-strings*. This change means you must be using

--- a/mqttany/config.py
+++ b/mqttany/config.py
@@ -40,6 +40,9 @@ from logger import log_traceback
 
 log = logger.get_logger()
 
+CONF_KEY_VERSION = "version"
+CONFIG_VERSION = [1, 0]
+
 
 def load_config(config_file: str) -> dict:
     """
@@ -67,6 +70,21 @@ def load_config(config_file: str) -> dict:
         except:
             log.error("Config file contains errors")
             log_traceback(log, limit=0)
+
+        if [
+            int(s) for s in config.get(CONF_KEY_VERSION, "0.0").split(".")
+        ] < CONFIG_VERSION:
+            if CONF_KEY_VERSION in config:
+                log.error("Config file version is '%s'", config[CONF_KEY_VERSION])
+            else:
+                log.error("Config file does not specify a version")
+            log.error(
+                "This version of MQTTany requires a minimum config file version of '%s'",
+                ".".join([str(i) for i in CONFIG_VERSION]),
+            )
+            config = None
+        else:
+            config.pop(CONF_KEY_VERSION, None)
     else:
         log.error("Config file does not exist: %s", config_file)
 

--- a/mqttany/config/mqttany.yml
+++ b/mqttany/config/mqttany.yml
@@ -4,6 +4,10 @@
 
 
 
+### Config file version
+version: '1.0'
+
+
 ######## MQTT Module ########
 mqtt:
 


### PR DESCRIPTION
This will prevent MQTTany from running with an outdated config file that may cause errors or strange behavior. Config version number will incriment when incompatible changes occur in the config format.