### PR TITLE
Move fps to array config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,10 @@ automation setup much in order to interface with this version of MQTTany.
   * **MQTT** - Messages arriving on ``{node}/{property}/+/#`` will match and the callback
     for the property will be called. The callback should further inspect the topic before
     taking action.
-  * Remove the modified version of `libsacn` that was bundled with the LED module. The
-    needed modifications are now available upstream in version 1.4.5.
+  * **LED** - Remove the modified version of `libsacn` that was bundled with the LED module.
+    The needed modifications are now available upstream in version 1.4.5.
+  * **LED** - Move the `fps` option from module config to array config allowing per-array
+    FPS setting. This is now published when the array is setup also.
 
 * **Fixed**
   * Remove requirements file for old MCP230xx module that was removed in v0.10.0.

--- a/mqttany/config/mqttany.yml
+++ b/mqttany/config/mqttany.yml
@@ -219,11 +219,6 @@ mqtt:
   # Animation to play when MQTTany loads
   #anim startup: 'test.array'
 
-  ### Animation Frame Rate
-  # Frame rate for animations, you may need to decrease this for
-  # longer arrays or certain interface types.
-  #anim fps: 60
-
   ### Array Configuration
   #array-id:
 
@@ -255,6 +250,11 @@ mqtt:
     # The byte order for the color data sent to the LEDs.
     # See the 'test.order' animation for how to determine this
     #color order: '{default}'
+
+    ### Animation Frame Rate
+    # Frame rate for animations, you may need to decrease this for
+    # longer arrays or certain interface types.
+    #anim fps: 60
 
     ### Interface Specific Options
     # Each interface may have some options specific to it

--- a/mqttany/modules/led/anim.py
+++ b/mqttany/modules/led/anim.py
@@ -35,7 +35,7 @@ import importlib.util
 import logger
 from logger import log_traceback
 
-from modules.led.common import log, CONFIG, CONF_KEY_ANIM_DIR, CONF_KEY_ANIM_FPS
+from modules.led.common import log, CONFIG, CONF_KEY_ANIM_DIR
 
 log = logger.get_module_logger("led.anim")
 
@@ -145,7 +145,6 @@ def load_animations():
 
     # add utils to anims
     for func in anims:
-        anims[func].__globals__["FRAME_MS"] = round(1.0 / CONFIG[CONF_KEY_ANIM_FPS], 5)
         anims[func].__globals__["log"] = logger.get_module_logger(f"led.anim.{func}")
         for util in utils:
             anims[func].__globals__[util.__name__] = util

--- a/mqttany/modules/led/array/__init__.py
+++ b/mqttany/modules/led/array/__init__.py
@@ -36,6 +36,7 @@ from modules.led.common import (
     CONF_KEY_PER_PIXEL,
     CONF_KEY_COLOR_ORDER,
     CONF_KEY_BRIGHTNESS,
+    CONF_KEY_ANIM_FPS,
 )
 from modules.led.array import rpi, e131
 
@@ -56,6 +57,7 @@ def getArray(array_id, array_config, log):
             count=array_config[CONF_KEY_COUNT],
             leds_per_pixel=array_config[CONF_KEY_PER_PIXEL],
             color_order=array_config[CONF_KEY_COLOR_ORDER],
+            fps=array_config[CONF_KEY_ANIM_FPS],
             init_brightness=array_config[CONF_KEY_BRIGHTNESS],
             array_config=array_config,
         )

--- a/mqttany/modules/led/array/e131.py
+++ b/mqttany/modules/led/array/e131.py
@@ -71,12 +71,13 @@ class sacnArray(baseArray):
         count: int,
         leds_per_pixel: int,
         color_order: str,
+        fps: int,
         array_config: dict,
     ):
         """
         Returns an LED object that outputs via sACN
         """
-        super().__init__(id, name, count, leds_per_pixel, color_order)
+        super().__init__(id, name, count, leds_per_pixel, color_order, fps)
         self._log = logger.get_module_logger(f"led.sacn.{self.id}")
         self._brightness = (
             255

--- a/mqttany/modules/led/array/rpi.py
+++ b/mqttany/modules/led/array/rpi.py
@@ -113,13 +113,14 @@ class rpiArray(baseArray):
         count: int,
         leds_per_pixel: int,
         color_order: str,
+        fps: int,
         init_brightness: int,
         array_config: dict,
     ):
         """
         Returns an LED object wrapping ``rpi_ws281x.PixelStrip``
         """
-        super().__init__(id, name, count, leds_per_pixel, color_order)
+        super().__init__(id, name, count, leds_per_pixel, color_order, fps)
         self._log = logger.get_module_logger(f"led.rpi.{self.id}")
         self._init_brightness = (
             255
@@ -307,6 +308,7 @@ def validateGPIO(
     count: int,
     leds_per_pixel: int,
     color_order: str,
+    fps: int,
     init_brightness: int,
     array_config: dict,
 ):
@@ -373,6 +375,7 @@ def validateGPIO(
                 count,
                 leds_per_pixel,
                 color_order,
+                fps,
                 init_brightness,
                 array_config,
             )

--- a/mqttany/modules/led/common.py
+++ b/mqttany/modules/led/common.py
@@ -32,13 +32,13 @@ __all__ = [
     "nodes",
     "CONF_KEY_ANIM_DIR",
     "CONF_KEY_ANIM_STARTUP",
-    "CONF_KEY_ANIM_FPS",
     "CONF_KEY_NAME",
     "CONF_KEY_OUTPUT",
     "CONF_KEY_COUNT",
     "CONF_KEY_PER_PIXEL",
     "CONF_KEY_BRIGHTNESS",
     "CONF_KEY_COLOR_ORDER",
+    "CONF_KEY_ANIM_FPS",
     "CONF_OPTIONS",
     "ANIM_KEY_NAME",
     "ANIM_KEY_REPEAT",
@@ -57,19 +57,18 @@ nodes = {}
 
 CONF_KEY_ANIM_DIR = "anim dir"
 CONF_KEY_ANIM_STARTUP = "anim startup"
-CONF_KEY_ANIM_FPS = "anim fps"
 CONF_KEY_NAME = "name"
 CONF_KEY_OUTPUT = "output"
 CONF_KEY_COUNT = "count"
 CONF_KEY_PER_PIXEL = "leds per pixel"
 CONF_KEY_BRIGHTNESS = "brightness"
 CONF_KEY_COLOR_ORDER = "color order"
+CONF_KEY_ANIM_FPS = "anim fps"
 
 CONF_OPTIONS = OrderedDict(
     [
         (CONF_KEY_ANIM_DIR, {"type": (str, list), "default": []}),
         (CONF_KEY_ANIM_STARTUP, {"type": str, "default": "test.array"}),
-        (CONF_KEY_ANIM_FPS, {"type": int, "default": 60}),
         (
             "regex:.+",
             {
@@ -97,6 +96,7 @@ CONF_OPTIONS = OrderedDict(
                         "BGRW",
                     ],
                 },
+                CONF_KEY_ANIM_FPS: {"type": int, "default": 60},
             },
         ),
     ]


### PR DESCRIPTION
Move the `fps` option from module config to array config allowing per-array FPS setting. This is now published when the array is setup also.