### PR TITLE
Add secret flag for config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ automation setup much in order to interface with this version of MQTTany.
   * Config file version key. This will prevent MQTTany from running with an outdated
     config file that may cause errors or strange behavior. Config version number will
     incriment when incompatible changes occur in the config format.
+  * Config option flag `secret` to obfuscate values in the log for passwords, etc.
 
 * **Changed**
   * Convert all string formatting to use *f-strings*. This change means you must be using

--- a/mqttany/config.py
+++ b/mqttany/config.py
@@ -140,7 +140,9 @@ def parse_config(
                         if isinstance(value, option.get("type", type(value))):
                             log.trace(
                                 "Got value '%s' for config option '%s'",
-                                "*" * len(value) if "pass" in name.lower() else value,
+                                "*" * len(value)
+                                if option.get("secret", False)
+                                else value,
                                 name,
                             )
                             config[name] = value
@@ -174,7 +176,7 @@ def parse_config(
                     else:
                         log.trace(
                             "Got value '%s' for config option '%s'",
-                            "*" * len(value) if "pass" in name.lower() else value,
+                            "*" * len(value) if option.get("secret", False) else value,
                             name,
                         )
                         config[name] = value

--- a/mqttany/modules/mqtt.py
+++ b/mqttany/modules/mqtt.py
@@ -72,7 +72,7 @@ CONF_OPTIONS = OrderedDict(
         (CONF_KEY_PORT, {"type": int, "default": 1883}),
         (CONF_KEY_CLIENTID, {"default": "{hostname}"}),
         (CONF_KEY_USERNAME, {"default": ""}),
-        (CONF_KEY_PASSWORD, {"default": ""}),
+        (CONF_KEY_PASSWORD, {"default": "", "secret": True}),
         (CONF_KEY_QOS, {"type": int, "default": 0}),
         (CONF_KEY_RETAIN, {"type": bool, "default": False}),
         (CONF_KEY_TOPIC_ROOT, {"default": "{client_id}"}),

--- a/templates/communication/package/common.py
+++ b/templates/communication/package/common.py
@@ -65,6 +65,7 @@ CONF_OPTIONS = OrderedDict(
                 # if a `default` is given the option is assumed to be optional
                 "type": int,
                 "default": 200,
+                "secret": True,  # This will cause the value to appear as *'s in the log
             },
         ),
         (  # subsections are also possible

--- a/templates/communication/simple/comm_template.py
+++ b/templates/communication/simple/comm_template.py
@@ -78,6 +78,7 @@ CONF_OPTIONS = OrderedDict(
                 # if a `default` is given the option is assumed to be optional
                 "type": int,
                 "default": 200,
+                "secret": True,  # This will cause the value to appear as *'s in the log
             },
         ),
         (  # subsections are also possible

--- a/templates/interface/package/common.py
+++ b/templates/interface/package/common.py
@@ -97,6 +97,7 @@ CONF_OPTIONS = OrderedDict(
                 # if a `default` is given the option is assumed to be optional
                 "type": int,
                 "default": 200,
+                "secret": True,  # This will cause the value to appear as *'s in the log
             },
         ),
         (  # subsections are also possible

--- a/templates/interface/simple/interface_template.py
+++ b/templates/interface/simple/interface_template.py
@@ -68,6 +68,7 @@ CONF_OPTIONS = OrderedDict(
                 # if a `default` is given the option is assumed to be optional
                 "type": int,
                 "default": 200,
+                "secret": True,  # This will cause the value to appear as *'s in the log
             },
         ),
         (  # subsections are also possible


### PR DESCRIPTION
Config option flag `secret` to obfuscate values in the log for passwords, etc.