### PR TITLE
Cleanup logger names and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,15 @@ automation setup much in order to interface with this version of MQTTany.
   * Updated Adafruit Platform Detect version from 1.x to 2.x.
   * **GPIO** - Change language for `direction` to `pin mode` to be less specific and lay
     ground work for additional pin modes.
+  * Consolidate `get_module_logger` and `get_logger` into single function and remove
+    leading `mqttany` from all logger names.
 
 * **Fixed**
   * Remove requirements file for old MCP230xx module that was removed in v0.10.0.
   * Fix logger checking if ``TRACE`` logging was enabled for ``WARN`` messages.
   * Core not exiting correctly if an exception occurred in the core.
+  * Logging not truncating process name or logger name, this could have resulted in
+    misaligned log entries.
 
 ## 0.11.0
 

--- a/mqttany/bus.py
+++ b/mqttany/bus.py
@@ -44,7 +44,7 @@ from modules import (
     ATTR_NODES,
 )
 
-log = logger.get_module_logger("bus")
+log = logger.get_logger("bus")
 
 # Communication module queues
 receive_queue = mproc.Queue()
@@ -70,7 +70,7 @@ class ReceiveThread(threading.Thread):
 
     def __init__(self):
         super().__init__(name="Receive")
-        self.log = logger.get_module_logger("bus.receive")
+        self.log = logger.get_logger("bus.receive")
 
     def run(self):
         self.log.trace("Message Bus Receive thread started successfully")
@@ -115,7 +115,7 @@ class TransmitThread(threading.Thread):
 
     def __init__(self):
         super().__init__(name="Transmit")
-        self.log = logger.get_module_logger("bus.transmit")
+        self.log = logger.get_logger("bus.transmit")
 
     def run(self):
         self.log.trace("Message Bus Transmit thread started successfully")

--- a/mqttany/core.py
+++ b/mqttany/core.py
@@ -52,7 +52,7 @@ from modules import (
     ATTR_NODES,
 )
 
-log = logger.get_module_logger("core")
+log = logger.get_logger("core")
 communication_modules = []
 interface_modules = []
 

--- a/mqttany/modules/gpio/common.py
+++ b/mqttany/modules/gpio/common.py
@@ -50,7 +50,7 @@ from enum import Enum
 import logger
 from common import DataType, BusNode, BusProperty
 
-log = logger.get_module_logger("gpio")
+log = logger.get_logger("gpio")
 CONFIG = {}
 
 publish_queue = None

--- a/mqttany/modules/gpio/lib/odroid.py
+++ b/mqttany/modules/gpio/lib/odroid.py
@@ -58,7 +58,7 @@ from modules.gpio.common import (
 )
 
 
-log = logger.get_module_logger("gpio.odroid")
+log = logger.get_logger("gpio.odroid")
 
 
 MAP_WIRINGPI_SETUP = {

--- a/mqttany/modules/gpio/lib/rpi.py
+++ b/mqttany/modules/gpio/lib/rpi.py
@@ -57,7 +57,7 @@ from modules.gpio.common import (
     TEXT_GPIO_MODE,
 )
 
-log = logger.get_module_logger("gpio.rpi")
+log = logger.get_logger("gpio.rpi")
 
 
 MAP_WIRINGPI_SETUP = {

--- a/mqttany/modules/gpio/pin/digital.py
+++ b/mqttany/modules/gpio/pin/digital.py
@@ -108,7 +108,7 @@ class Digital(Pin):
 
     def __init__(self, pin: int, id: str, name: str, pin_config: dict = {}):
         super().__init__(pin, id, name, pin_config)
-        self._log = logger.get_module_logger("gpio.digital")
+        self._log = logger.get_logger("gpio.digital")
         self._pulse_timer = None
         self._interrupt = pin_config[CONF_KEY_INTERRUPT]
         self._resistor = pin_config[CONF_KEY_RESISTOR]

--- a/mqttany/modules/i2c/common.py
+++ b/mqttany/modules/i2c/common.py
@@ -47,7 +47,7 @@ import logger
 from config import resolve_type
 from common import DataType, BusNode, BusProperty
 
-log = logger.get_module_logger("i2c")
+log = logger.get_logger("i2c")
 CONFIG = {}
 
 publish_queue = None

--- a/mqttany/modules/i2c/device/mcp230xx.py
+++ b/mqttany/modules/i2c/device/mcp230xx.py
@@ -629,7 +629,7 @@ class MCP23008(MCP230xx):
         device_config: dict,
     ):
         super().__init__(id, name, device, address, bus, bus_path)
-        self._log = logger.get_module_logger("i2c.mcp23008")
+        self._log = logger.get_logger("i2c.mcp23008")
         self._pin_max = 7
         self._pins = [None] * (self._pin_max + 1)
         self._gpio = 0x0000
@@ -724,7 +724,7 @@ class MCP23017(MCP230xx):
         device_config: dict,
     ):
         super().__init__(id, name, device, address, bus, bus_path)
-        self._log = logger.get_module_logger("i2c.mcp23017")
+        self._log = logger.get_logger("i2c.mcp23017")
         self._pin_max = 15
         self._pins = [None] * (self._pin_max + 1)
         self._gpio = 0x0000

--- a/mqttany/modules/led/anim.py
+++ b/mqttany/modules/led/anim.py
@@ -37,7 +37,7 @@ from logger import log_traceback
 
 from modules.led.common import log, CONFIG, CONF_KEY_ANIM_DIR
 
-log = logger.get_module_logger("led.anim")
+log = logger.get_logger("led.anim")
 
 DEFAULT_PATH = "/etc/mqttany/led-anim"
 
@@ -145,7 +145,7 @@ def load_animations():
 
     # add utils to anims
     for func in anims:
-        anims[func].__globals__["log"] = logger.get_module_logger(f"led.anim.{func}")
+        anims[func].__globals__["log"] = logger.get_logger(f"led.anim.{func}")
         for util in utils:
             anims[func].__globals__[util.__name__] = util
 

--- a/mqttany/modules/led/array/e131.py
+++ b/mqttany/modules/led/array/e131.py
@@ -39,7 +39,7 @@ from modules.led.common import (
 )
 from modules.led.array.base import baseArray
 
-log = logger.get_module_logger("led.sacn")
+log = logger.get_logger("led.sacn")
 
 CONF_KEY_SACN = "sacn"
 CONF_KEY_UNIVERSE = "universe"
@@ -78,7 +78,7 @@ class sacnArray(baseArray):
         Returns an LED object that outputs via sACN
         """
         super().__init__(id, name, count, leds_per_pixel, color_order, fps)
-        self._log = logger.get_module_logger(f"led.sacn.{self.id}")
+        self._log = logger.get_logger(f"led.sacn.{self.id}")
         self._brightness = (
             255
             if array_config[CONF_KEY_BRIGHTNESS] > 255

--- a/mqttany/modules/led/array/rpi.py
+++ b/mqttany/modules/led/array/rpi.py
@@ -121,7 +121,7 @@ class rpiArray(baseArray):
         Returns an LED object wrapping ``rpi_ws281x.PixelStrip``
         """
         super().__init__(id, name, count, leds_per_pixel, color_order, fps)
-        self._log = logger.get_module_logger(f"led.rpi.{self.id}")
+        self._log = logger.get_logger(f"led.rpi.{self.id}")
         self._init_brightness = (
             255
             if array_config[CONF_KEY_BRIGHTNESS] > 255
@@ -362,7 +362,7 @@ def validateGPIO(
             pin_ok = True  # SPI0-MOSI
 
         if not pin_ok:
-            logger.get_module_logger("led.rpi").error(
+            logger.get_logger("led.rpi").error(
                 "GPIO%02d cannot be used for LED control on %s",
                 array_config[CONF_KEY_RPI][CONF_KEY_GPIO],
                 board_id,
@@ -381,10 +381,10 @@ def validateGPIO(
             )
 
     else:
-        logger.get_module_logger("led.rpi").error(
+        logger.get_logger("led.rpi").error(
             "This module only supports GPIO output on certain Raspberry Pi boards"
         )
-        logger.get_module_logger("led.rpi").error(
+        logger.get_logger("led.rpi").error(
             "Please see the documentation for supported boards"
         )
 

--- a/mqttany/modules/led/common.py
+++ b/mqttany/modules/led/common.py
@@ -49,7 +49,7 @@ from collections import OrderedDict
 
 import logger
 
-log = logger.get_module_logger("led")
+log = logger.get_logger("led")
 CONFIG = {}
 
 publish_queue = None

--- a/mqttany/modules/mqtt.py
+++ b/mqttany/modules/mqtt.py
@@ -46,7 +46,7 @@ from modules import ModuleType
 
 _module_type = ModuleType.COMMUNICATION
 
-log = logger.get_module_logger()
+log = logger.get_logger()
 CONFIG = {}
 
 core_queue = None

--- a/mqttany/modules/onewire/bus/wire1.py
+++ b/mqttany/modules/onewire/bus/wire1.py
@@ -33,7 +33,7 @@ from typing import List
 import logger
 from modules.onewire.bus.base import OneWireBus
 
-log = logger.get_module_logger("onewire.wire1")
+log = logger.get_logger("onewire.wire1")
 
 CONF_OPTIONS = {}
 CONF_BUS_SELECTION = ["w1", "W1", "wire1", "WIRE1", "Wire1"]

--- a/mqttany/modules/onewire/common.py
+++ b/mqttany/modules/onewire/common.py
@@ -44,7 +44,7 @@ from collections import OrderedDict
 import logger
 from common import DataType, BusNode, BusProperty
 
-log = logger.get_module_logger("onewire")
+log = logger.get_logger("onewire")
 CONFIG = {}
 
 publish_queue = None

--- a/mqttany/modules/onewire/device/ds18x20.py
+++ b/mqttany/modules/onewire/device/ds18x20.py
@@ -74,7 +74,7 @@ class DS18x20(OneWireDevice):
         device_config: dict,
     ):
         super().__init__(id, name, device, address, bus)
-        self._log = logger.get_module_logger("onewire.ds18x20")
+        self._log = logger.get_logger("onewire.ds18x20")
         self._unit = (
             device_config.get(CONF_KEY_DS18X20, {}).get(CONF_KEY_UNIT, "C").upper()
         )

--- a/mqttany/modules/xset.py
+++ b/mqttany/modules/xset.py
@@ -44,7 +44,7 @@ CONF_OPTIONS = OrderedDict(
     ]
 )
 
-log = logger.get_module_logger("xset")
+log = logger.get_logger("xset")
 CONFIG = {}
 
 publish_queue = None

--- a/mqttany/mqttany.py
+++ b/mqttany/mqttany.py
@@ -34,7 +34,7 @@ import version as mqttanyversion
 
 __version__ = mqttanyversion.__version__
 
-log = logger.get_logger()
+log = logger.get_logger("core")
 queue_core = mproc.Queue()
 
 # pylint: disable=logging-format-interpolation

--- a/templates/communication/package/common.py
+++ b/templates/communication/package/common.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 
 import logger
 
-log = logger.get_module_logger("comm_pkg_template")
+log = logger.get_logger("comm_pkg_template")
 CONFIG = {}
 
 # This queue is used to request that MQTTany exit. If a fatal error is encountered put

--- a/templates/communication/simple/comm_template.py
+++ b/templates/communication/simple/comm_template.py
@@ -37,7 +37,7 @@ from bus import get_property_from_path
 
 _module_type = ModuleType.COMMUNICATION
 
-log = logger.get_module_logger()
+log = logger.get_logger()
 CONFIG = {}
 
 # This queue is used to request that MQTTany exit. If a fatal error is encountered put

--- a/templates/interface/package/common.py
+++ b/templates/interface/package/common.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 import logger
 
 # If you don't specify the logging name you will get `interface_pkg_template.common` here
-log = logger.get_module_logger("interface_pkg_template")
+log = logger.get_logger("interface_pkg_template")
 CONFIG = {}
 
 # If the module publishes messages it must have the `publish_queue` attribute. It will

--- a/templates/interface/simple/interface_template.py
+++ b/templates/interface/simple/interface_template.py
@@ -36,7 +36,7 @@ from modules import ModuleType
 
 _module_type = ModuleType.INTERFACE
 
-log = logger.get_module_logger()
+log = logger.get_logger()
 CONFIG = {}
 
 # If the module publishes messages it must have the `publish_queue` attribute. It will


### PR DESCRIPTION
* Consolidate `get_module_logger` and `get_logger` into single function and remove leading `mqttany` from all logger names.
* Logging not truncating process name or logger name, this could have resulted in misaligned log entries.