### PR TITLE
Improve log traceback formatting

### DIFF
--- a/mqttany/logger.py
+++ b/mqttany/logger.py
@@ -199,9 +199,28 @@ def log_traceback(log, limit=None):
     """
     Print a traceback to the log
     """
+    message = ""
     for layer in traceback.format_exception(*sys.exc_info(), limit=limit):
         for line in layer.split("\n"):
-            log.error(line)
+            message = (
+                message
+                + (
+                    " "
+                    * (
+                        30
+                        + _LOG_LEN_LEVEL
+                        + _LOG_LEN_NAME
+                        + (
+                            0
+                            if logging.getLogger("mqttany").level > DEBUG
+                            else _LOG_LEN_PROCESS + 3
+                        )
+                    )
+                )
+                + line
+                + "\n"
+            )
+    log.error(message.strip() + "\n")
 
 
 def uninit():


### PR DESCRIPTION
`log_traceback` now formats the entire traceback into a single log entry with the correct indentation to match the log format.