### PR TITLE
Add I2C bus path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ automation setup much in order to interface with this version of MQTTany.
     config file that may cause errors or strange behavior. Config version number will
     incriment when incompatible changes occur in the config format.
   * Config option flag `secret` to obfuscate values in the log for passwords, etc.
+  * **I2C** If `bus` is a number, checks for path `/dev/i2c{bus}` as well as
+    `/dev/i2c-{bus}` now.
 
 * **Changed**
   * Convert all string formatting to use *f-strings*. This change means you must be using

--- a/mqttany/modules/i2c/common.py
+++ b/mqttany/modules/i2c/common.py
@@ -110,16 +110,18 @@ def validateBus(bus):
     Validates I2C bus ID or full path.
     Returns ``None`` if bus is invalid.
     """
+    path = None
     if isinstance(bus, int):
-        filepath = f"/dev/i2c-{bus}"
+        if os.access(f"/dev/i2c-{bus}", os.F_OK, effective_ids=True):
+            path = f"/dev/i2c-{bus}"
+        elif os.access(f"/dev/i2c{bus}", os.F_OK, effective_ids=True):
+            path = f"/dev/i2c{bus}"
+        else:
+            log.error("Unknown I2C bus specifier '%s'", bus)
     elif isinstance(bus, str):
-        filepath = bus
-    else:
-        log.error("Unknown I2C bus specifier '%s'", bus)
-        return None
+        if os.access(bus, os.F_OK, effective_ids=True):
+            path = bus
+        else:
+            log.error("I2C bus path '%s' does not exist", bus)
 
-    if not os.path.exists(filepath):
-        log.error("I2C bus path '%s' does not exist", filepath)
-        return None
-
-    return filepath
+    return path


### PR DESCRIPTION
When providing `bus` as a number MQTTany would only check for `/dev/i2c-{bus}` but now will also check for `/dev/i2c{bus}`.