### PR TITLE
Improve log traceback formatting (superceeds #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,8 @@ automation setup much in order to interface with this version of MQTTany.
   * Updated Adafruit Platform Detect version from 1.x to 2.x.
   * Consolidate `get_module_logger` and `get_logger` into single function and remove
     leading `mqttany` from all logger names.
-  * `log_traceback` now formats entire traceback into a single log entry with correct
-    indentation to match other log messages.
+  * `log_traceback` now formats entire traceback into a single log entry on a new line,
+    like a standard stack trace.
 
 * **Fixed**
   * Remove requirements file for old MCP230xx module that was removed in v0.10.0.

--- a/mqttany/logger.py
+++ b/mqttany/logger.py
@@ -199,28 +199,9 @@ def log_traceback(log, limit=None):
     """
     Print a traceback to the log
     """
-    message = ""
-    for layer in traceback.format_exception(*sys.exc_info(), limit=limit):
-        for line in layer.split("\n"):
-            message = (
-                message
-                + (
-                    " "
-                    * (
-                        30
-                        + _LOG_LEN_LEVEL
-                        + _LOG_LEN_NAME
-                        + (
-                            0
-                            if logging.getLogger("mqttany").level > DEBUG
-                            else _LOG_LEN_PROCESS + 3
-                        )
-                    )
-                )
-                + line
-                + "\n"
-            )
-    log.error(message.strip() + "\n")
+    log.error(
+        "\n\n" + "".join(traceback.format_exception(*sys.exc_info(), limit=limit))
+    )
 
 
 def uninit():


### PR DESCRIPTION
`log_traceback` now formats entire traceback into a single log entry on a new line, like a standard stack trace.

This superceeds #60 