### PR TITLE
LED fix error in cleanup

### DIFF
--- a/mqttany/modules/led/array/base.py
+++ b/mqttany/modules/led/array/base.py
@@ -161,7 +161,7 @@ class baseArray:
         Cleanup actions when stopping
         **SUBCLASSES MUST SUPER() THIS METHOD**
         """
-        if self._anim_manager.is_alive():
+        if self._anim_manager and self._anim_manager.is_alive():
             self._anim_queue.put_nowait(POISON_PILL)
             self._anim_manager.join()
         self._setup = False


### PR DESCRIPTION
Fix an that would occur when unloading the LED module if the animation manager thread was never created. This would occur if the array setup failed.