### PR TITLE
LED fix RPi permission check and message

### DIFF
--- a/mqttany/modules/led/array/rpi.py
+++ b/mqttany/modules/led/array/rpi.py
@@ -185,10 +185,9 @@ class rpiArray(baseArray):
             return False
 
         if self._pin != 10:
-            if not os.access("/dev/mem", os.R_OK | os.W_OK):
+            if not os.access("/dev/mem", os.R_OK | os.W_OK, effective_ids=True):
                 self._log.error(
                     "No read/write access to '/dev/mem', try running with root privileges"
-                    "or adding the user trying to run MQTTany to the group 'kmem'"
                 )
                 return False
 


### PR DESCRIPTION
RPi array class in LED module would check with real UID/GID for read/write permission on `/dev/mem` but this will fail for regular users running `sudo`. Added `effective_ids=True` to `os.access` call.

Following a failure on this check, the log message suggested giving the user access to `/dev/mem`, which I have since learned is a **horrendous** security hole and such suggestion has not been removed.