### PR TITLE
Config add conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ automation setup much in order to interface with this version of MQTTany.
     [#71](https://github.com/CrazyIvan359/mqttany/pull/71)
   * **GPIO** - support for counter pins.
     [#75](https://github.com/CrazyIvan359/mqttany/pull/75)
+  * Config option `conditions` allows matching a key at the same level to a value.
+    Useful for sections or options that are required only for certain modes.
+    [#77](https://github.com/CrazyIvan359/mqttany/pull/77)
 
 * **Changed**
   * Convert all string formatting to use *f-strings*. This change means you must be using

--- a/templates/communication/package/common.py
+++ b/templates/communication/package/common.py
@@ -76,6 +76,13 @@ CONF_OPTIONS = OrderedDict(
                 # if a subsection is optional you must specify this, if this
                 # is omitted the subsection is assumed to be required.
                 "required": False,
+                # conditions allows you to match a key at the same level (where CONF_KEY_SUBSECTION
+                # is in this example) to a specific value. Must provide a list of tuples
+                # where the first element is the key and the second is the value to match.
+                # If any of the conditions match the option will be parsed. This can be
+                # used ex. to have required sections only if an option is set to a specific
+                # value. Can also be used on regular options.
+                "conditions": [(CONF_KEY_FIXED_TYPE, 200)],
                 CONF_KEY_SELECTION: {
                     # you can limit the possible values by providing a list or dict of
                     # possibilities. The config will be invalid if the value is not in

--- a/templates/communication/simple/comm_template.py
+++ b/templates/communication/simple/comm_template.py
@@ -89,6 +89,13 @@ CONF_OPTIONS = OrderedDict(
                 # if a subsection is optional you must specify this, if this
                 # is omitted the subsection is assumed to be required.
                 "required": False,
+                # conditions allows you to match a key at the same level (where CONF_KEY_SUBSECTION
+                # is in this example) to a specific value. Must provide a list of tuples
+                # where the first element is the key and the second is the value to match.
+                # If any of the conditions match the option will be parsed. This can be
+                # used ex. to have required sections only if an option is set to a specific
+                # value. Can also be used on regular options.
+                "conditions": [(CONF_KEY_FIXED_TYPE, 200)],
                 CONF_KEY_SELECTION: {
                     # you can limit the possible values by providing a list or dict of
                     # possibilities. The config will be invalid if the value is not in

--- a/templates/interface/package/common.py
+++ b/templates/interface/package/common.py
@@ -108,6 +108,13 @@ CONF_OPTIONS = OrderedDict(
                 # if a subsection is optional you must specify this, if this
                 # is omitted the subsection is assumed to be required.
                 "required": False,
+                # conditions allows you to match a key at the same level (where CONF_KEY_SUBSECTION
+                # is in this example) to a specific value. Must provide a list of tuples
+                # where the first element is the key and the second is the value to match.
+                # If any of the conditions match the option will be parsed. This can be
+                # used ex. to have required sections only if an option is set to a specific
+                # value. Can also be used on regular options.
+                "conditions": [(CONF_KEY_FIXED_TYPE, 200)],
                 CONF_KEY_SELECTION: {
                     # you can limit the possible values by providing a list or dict of
                     # possibilities. The config will be invalid if the value is not in

--- a/templates/interface/simple/interface_template.py
+++ b/templates/interface/simple/interface_template.py
@@ -79,6 +79,13 @@ CONF_OPTIONS = OrderedDict(
                 # if a subsection is optional you must specify this, if this
                 # is omitted the subsection is assumed to be required.
                 "required": False,
+                # conditions allows you to match a key at the same level (where CONF_KEY_SUBSECTION
+                # is in this example) to a specific value. Must provide a list of tuples
+                # where the first element is the key and the second is the value to match.
+                # If any of the conditions match the option will be parsed. This can be
+                # used ex. to have required sections only if an option is set to a specific
+                # value. Can also be used on regular options.
+                "conditions": [(CONF_KEY_FIXED_TYPE, 200)],
                 CONF_KEY_SELECTION: {
                     # you can limit the possible values by providing a list or dict of
                     # possibilities. The config will be invalid if the value is not in


### PR DESCRIPTION
Add config option `conditions` to allow matching a key at the same level to a value. This allows, for example, a section to be required only if a key is set to a certain value.