### PR TITLE
Improve config handling of invalid conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Development
 
+* **Added**
+  * Config parser now considers required sections with defaults for all options to be
+    valid and will populate the section in the returned configuration.
+
+* **Fixed**
+  * Config parser was reporting valid configuration for optional conditional sections
+    containing invalid values. Fixes problem 1 in [#80](https://github.com/CrazyIvan359/mqttany/issues/80).
+
 ## 0.12.0
 
 ### Major Core Rewrite

--- a/mqttany/config.py
+++ b/mqttany/config.py
@@ -125,18 +125,13 @@ def parse_config(
                         return False
 
             if condition_matched != False:
-                if value == "**NO DATA**" and option.get("type", None) == "section":
-                    if option.get("required", True):
-                        log.error("Missing required section '%s'", name)
-                        return False
-                    elif condition_matched:
-                        log.trace("Descending into section '%s'", name)
-                        section_valid, config[name] = parse_dict({}, option)
-                        return True
-
-                elif isinstance(value, dict):
+                if isinstance(value, dict) or (
+                    value == "**NO DATA**" and option.get("type", None) == "section"
+                ):
                     log.trace("Descending into section '%s'", name)
-                    section_valid, section_config = parse_dict(value, option)
+                    section_valid, section_config = parse_dict(
+                        {} if value == "**NO DATA**" else value, option
+                    )
                     if not section_valid and option.get("required", True):
                         log.error("Required section '%s' is not valid", name)
                         return False

--- a/mqttany/modules/gpio/pin/counter.py
+++ b/mqttany/modules/gpio/pin/counter.py
@@ -77,7 +77,6 @@ CONF_OPTIONS = {
         },
         CONF_KEY_COUNTER: {
             "type": "section",
-            "required": False,
             "conditions": [(CONF_KEY_PIN_MODE, "COUNTER")],
             CONF_KEY_INTERVAL: {"default": 60, "type": int},
             CONF_KEY_INTERRUPT: {

--- a/mqttany/modules/gpio/pin/digital.py
+++ b/mqttany/modules/gpio/pin/digital.py
@@ -73,7 +73,6 @@ CONF_OPTIONS = {
         },
         CONF_KEY_DIGITAL: {
             "type": "section",
-            "required": False,
             "conditions": [
                 (CONF_KEY_PIN_MODE, PinMode.INPUT),
                 (CONF_KEY_PIN_MODE, PinMode.OUTPUT),

--- a/mqttany/modules/i2c/device/mcp230xx.py
+++ b/mqttany/modules/i2c/device/mcp230xx.py
@@ -70,7 +70,6 @@ CONF_OPTIONS = {
         CONF_KEY_MCP: OrderedDict(
             [
                 ("type", "section"),
-                ("required", True),
                 (
                     "conditions",
                     [(CONF_KEY_DEVICE, "mcp23008"), (CONF_KEY_DEVICE, "mcp23017")],

--- a/mqttany/modules/led/array/e131.py
+++ b/mqttany/modules/led/array/e131.py
@@ -46,7 +46,6 @@ CONF_OPTIONS = {
         CONF_KEY_OUTPUT: {"selection": {"sacn": "sacn", "sACN": "sacn"}},
         CONF_KEY_SACN: {
             "type": "section",
-            "required": False,
             "conditions": [(CONF_KEY_OUTPUT, "sacn")],
             CONF_KEY_UNIVERSE: {"type": int, "default": 1},
             CONF_KEY_ADDRESS: {"type": str, "default": None},

--- a/mqttany/modules/led/array/rpi.py
+++ b/mqttany/modules/led/array/rpi.py
@@ -47,7 +47,6 @@ CONF_OPTIONS = {
         CONF_KEY_OUTPUT: {"selection": {"rpi": "rpi", "RPi": "rpi"}},
         CONF_KEY_RPI: {
             "type": "section",
-            "required": True,
             "conditions": [(CONF_KEY_OUTPUT, "rpi")],
             CONF_KEY_GPIO: {"type": int},
             CONF_KEY_CHIP: {

--- a/mqttany/modules/onewire/device/ds18x20.py
+++ b/mqttany/modules/onewire/device/ds18x20.py
@@ -40,7 +40,6 @@ CONF_KEY_UNIT = "unit"
 CONF_OPTIONS = {  # will be added to device section of core CONF_OPTIONS
     CONF_KEY_DS18X20: {
         "type": "section",
-        "required": False,
         CONF_KEY_UNIT: {
             "default": "C",
             "selection": ["C", "c", "F", "f"],


### PR DESCRIPTION
Config parser now considers required sections with defaults for all options to be valid and will populate the section in the returned configuration. This solves problem 1 in #80 where the parser reports the pin configuration to be valid but does not populate the invalid section because it thinks it is optional.

This was the intended behaviour when conditions were added. They are now only considered required if a condition matches *and* they are marked as required.