### PR TITLE
Fix yaml on/off boolean handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Development
 
+* **Changed**
+  * Config parser no long converts selection keys to strings before matching.
+
 * **Added**
   * Config parser now considers required sections with defaults for all options to be
     valid and will populate the section in the returned configuration.
@@ -9,6 +12,8 @@
 * **Fixed**
   * Config parser was reporting valid configuration for optional conditional sections
     containing invalid values. Fixes problem 1 in [#80](https://github.com/CrazyIvan359/mqttany/issues/80).
+  * YAML returning booleans for unquoted `on` or `off` strings, booleans have been
+    added as accepted values where applicable to avoid confusion. Fixes [#80](https://github.com/CrazyIvan359/mqttany/issues/80).
 
 ## 0.12.0
 

--- a/mqttany/config.py
+++ b/mqttany/config.py
@@ -184,16 +184,16 @@ def parse_config(
                                 return False
 
                         elif "selection" in option:
-                            if str(value) in option["selection"]:
+                            if value in option["selection"]:
                                 log.trace(
                                     "Got selection '%s' for config option '%s'",
                                     value,
                                     name,
                                 )
                                 if isinstance(option["selection"], dict):
-                                    config[name] = option["selection"][str(value)]
+                                    config[name] = option["selection"][value]
                                 else:
-                                    config[name] = str(value)
+                                    config[name] = value
                             else:
                                 log.error(
                                     "Value '%s' for config option '%s' is not one of %s",

--- a/mqttany/modules/gpio/pin/digital.py
+++ b/mqttany/modules/gpio/pin/digital.py
@@ -68,6 +68,7 @@ CONF_OPTIONS = {
                 "pulldown": PinBias.PULL_DOWN,
                 "down": PinBias.PULL_DOWN,
                 "off": PinBias.NONE,
+                False: PinBias.NONE,
                 "none": PinBias.NONE,
             },
         },
@@ -88,7 +89,14 @@ CONF_OPTIONS = {
             },
             CONF_KEY_INVERT: {"type": bool, "default": False},
             CONF_KEY_INITIAL: {
-                "selection": {"ON": True, "on": True, "OFF": False, "off": False},
+                "selection": {
+                    "ON": True,
+                    "on": True,
+                    True: True,
+                    "OFF": False,
+                    "off": False,
+                    False: False,
+                },
                 "default": False,
             },
         },

--- a/mqttany/modules/i2c/device/mcp230xx.py
+++ b/mqttany/modules/i2c/device/mcp230xx.py
@@ -96,6 +96,7 @@ CONF_OPTIONS = {
                                 "pullup": Resistor.PULL_UP,
                                 "up": Resistor.PULL_UP,
                                 "off": Resistor.OFF,
+                                False: Resistor.OFF,
                                 "none": Resistor.OFF,
                             },
                         },
@@ -104,8 +105,10 @@ CONF_OPTIONS = {
                             "selection": {
                                 "ON": True,
                                 "on": True,
+                                True: True,
                                 "OFF": False,
                                 "off": False,
+                                False: False,
                             },
                             "default": False,
                         },


### PR DESCRIPTION
The YAML parser used for reading the configuration considers `on` or `off` (case in-sensitive) to be boolean values, this leads to confusion when using them without quotes when a string is expected. 

Boolean options have been added to selection lists where applicable and the config parser no longer converts the value to a string before attempt to match a selection key.

Fixes #80 