### PR TITLE
GPIO workaround for cdev timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Development
 
+* **Changed**
+  * GPIO CDev interrupts now use Python timestamp instead of event timestamp. On some
+    systems it seems that it reports uptime nanoseconds, not epoch nanoseconds. Fixes
+    [#86](https://github.com/CrazyIvan359/mqttany/issues/86).
+
 * **Fixed**
   * Math error in GPIO debounce calculation, multiplied when I should have divided. Also
     corrects cast error in CDev interrupt where epoch nanoseconds (1.6×10<sup>15</sup>)

--- a/mqttany/gpio/pins/digital.py
+++ b/mqttany/gpio/pins/digital.py
@@ -300,7 +300,8 @@ class cdevInterrupt(Interrupt):
         edge, ns = self._pin._interface.read_event()
         return (
             edge == periphery_PinEdge[PinEdge.RISING],
-            round(ns / 1000000000.0, 6),
+            # round(ns / 1000000000.0, 6),
+            now().timestamp(),
         )
 
 


### PR DESCRIPTION
GPIO CDev interrupts now use Python timestamp instead of event timestamp. On some systems it seems that it reports uptime nanoseconds, not epoch nanoseconds.

Solves #86 even though it's a bit of a hack...