### PR TITLE
GPIO fix digital pulse message handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * **Fixed**
   * Missing comma in Odroid C1+ and C2 board definitions.
+  * GPIO Digital pin pulse message handler using entire payload as state instead of
+    JSON property `'state'`.
 
 ## 0.12.2
 

--- a/mqttany/modules/gpio/pin/digital.py
+++ b/mqttany/modules/gpio/pin/digital.py
@@ -384,7 +384,7 @@ class Digital(Pin):
                         )
                         return
 
-                    state = str(resolve_type(content))
+                    state = str(resolve_type(state))
                     if state in TEXT_STATE:
                         self._pulse(time, TEXT_STATE[state])
                     else:


### PR DESCRIPTION
GPIO Digital pin pulse message handler using entire payload as state instead of JSON property `'state'`.