### PR TITLE
OneWire move get_w1_address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Migrate from pylint to Pylance for code checking in VSCode.
   * Convert entire codebase to be fully typed.
   * Migrate CI code check to Pyright from pylint.
+  * OneWire move `get_w1_address` function from base `bus` class to wire-1 bus class.
 
 * **Fixed**
   * Missing comma in Odroid C1+ and C2 board definitions.

--- a/mqttany/modules/onewire/bus/base.py
+++ b/mqttany/modules/onewire/bus/base.py
@@ -73,13 +73,6 @@ class OneWireBus:
         return bytes([crc])
 
     @staticmethod
-    def get_w1_address(address: str) -> str:
-        """
-        Returns the ``xx-xxxxxxxxxxxx`` style w1 address from the full 8 byte address.
-        """
-        return f"{address[:2]}-{address[2:]}"[:-2].lower()
-
-    @staticmethod
     def valid() -> bool:
         """
         Returns ``True`` if the bus is available.

--- a/mqttany/modules/onewire/bus/wire1.py
+++ b/mqttany/modules/onewire/bus/wire1.py
@@ -56,6 +56,13 @@ class Wire1(OneWireBus):
         """
         return os.path.exists(BUS_PATH)
 
+    @staticmethod
+    def get_w1_address(address: str) -> str:
+        """
+        Returns the ``xx-xxxxxxxxxxxx`` style w1 address from the full 8 byte address.
+        """
+        return f"{address[:2]}-{address[2:]}"[:-2].lower()
+
     def scan(self) -> t.List[str]:
         """
         Scan bus and return list of addresses found


### PR DESCRIPTION
Move `get_w1_address` function from base `bus` class to wire-1 bus class.