### PR TITLE
Fix Generic + Unknown board classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Development
 
+* **Fixed**
+  * *Unknown* and *Generic Linux* boards missing superclass init.
+
 ## 0.13.0
 
 * ***BREAKING CHANGE***

--- a/mqttany/gpio/boards/__init__.py
+++ b/mqttany/gpio/boards/__init__.py
@@ -38,12 +38,14 @@ from .base import Board
 
 class Unknown(Board):
     def __init__(self) -> None:
+        super().__init__()
         self._id = "UNRECOGNIZED"
         self._chips.append(999)  # dummy
 
 
 class Generic(Board):
     def __init__(self) -> None:
+        super().__init__()
         self._id = GENERIC_LINUX_PC
         self._chips.append(999)  # dummy
 


### PR DESCRIPTION
Fex *Unknown* and *Generic Linux* boards missing superclass init.

This bug was introduced in #96 when the base board class changed from using `__init_subclass__` to `__init__`.

Fixes #102 