### PR TITLE
GPIO add Kernel version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Development
 
+* **Added**
+  * Kernel version check to determine GPIO cdev availability and capabilities.
+
 * **Fixed**
   * *Unknown* and *Generic Linux* boards missing superclass init.
+  * GPIO error `Failed to setup GPIOxx using cdev, an invalid argument was given`
+    caused by attempting to use cdev bias setting that was only introduced in Linux
+    kernel v5.5. Fixes [#106](https://github.com/CrazyIvan359/mqttany/issues/106).
 
 ## 0.13.0
 

--- a/mqttany/gpio/common.py
+++ b/mqttany/gpio/common.py
@@ -42,6 +42,7 @@ import logger
 
 log = logger.get_logger("core.gpio")
 cdev = False
+cdev_bias = False
 sysfs = False
 
 


### PR DESCRIPTION
* **Added**
  * Kernel version check to determine GPIO cdev availability and capabilities.

* **Fixed**
  * GPIO error `Failed to setup GPIOxx using cdev, an invalid argument was given`
    caused by attempting to use cdev bias setting that was only introduced in Linux
    kernel v5.5. Fixes #106.