### PR TITLE
Fix interrupt bug from #108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+* **Fixed**
+  * Bug introduced in [#108](https://github.com/CrazyIvan359/mqttany/pull/108) causing
+    interrupts to not work on kernels <5.5.
+
 ## 0.14.0
 
 * **Added**

--- a/mqttany/gpio/pins/digital.py
+++ b/mqttany/gpio/pins/digital.py
@@ -160,8 +160,8 @@ class Digital(Pin):
                 f"/dev/gpiochip{self.chip}",
                 self.line,
                 periphery_PinMode[self.mode],
-                edge="none" if not common.cdev_bias else periphery_PinEdge[self.edge],
-                bias=periphery_PinBias[self.bias],
+                edge=periphery_PinEdge[self.edge],
+                bias="none" if not common.cdev_bias else periphery_PinBias[self.bias],
                 label="MQTTany",
             )
         except GPIOError as err:


### PR DESCRIPTION
Fix bug introduced in [#108](https://github.com/CrazyIvan359/mqttany/pull/108) causing interrupts to not work on kernels <5.5.