### PR TITLE
Move typing to comments in logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   * LED fix custom animations getting prefix `*` instead of actual module name. Fixes [#119](https://github.com/CrazyIvan359/mqttany/issues/119).
     [[#122](https://github.com/CrazyIvan359/mqttany/pull/122)]
   * I2C MCP230xx devices would not turn off their outputs on shutdown because `setup` flag was never set.
+  * Moved inline type to comment in logging to restore compatibility.
+    [[#131](https://github.com/CrazyIvan359/mqttany/pull/131)]
 
 ## 0.14.3
 

--- a/mqttany/logger.py
+++ b/mqttany/logger.py
@@ -88,7 +88,7 @@ _LOG_SECONDARY_COLORS = {
     }
 }
 
-_log_handlers: t.List[logging.Handler] = []  # type:ignore
+_log_handlers = []  # type:t.List[logging.Handler]
 
 
 class LogLevel(enum.IntEnum):


### PR DESCRIPTION
`logger.py` is supposed to be Python 2 compatible but had a single type statement inline. Moved to a comment so it is compatible.

```python
_log_handlers: t.List[logging.Handler] = []
```