### PR TITLE
Fix requirements notes in docs

### DIFF
--- a/source/communication/mqtt/index.rst
+++ b/source/communication/mqtt/index.rst
@@ -5,6 +5,12 @@ MQTT
 The MQTT module wraps the Paho MQTT Client library and connects to a broker to
 allow communication with home automation solutions or other controllers.
 
+.. admonition:: Don't forget to install the requirements
+
+    .. code-block:: shell
+
+        pip3 install -r requirements/mqtt.txt
+
 
 Paths
 =====

--- a/source/interface/onewire/index.rst
+++ b/source/interface/onewire/index.rst
@@ -6,12 +6,6 @@ OneWire
 The OneWire module provides access to Dallas/Maxim OneWire devices using the
 ``w1`` kernel module.
 
-.. admonition:: Don't forget to install the requirements
-
-    .. code-block:: shell
-
-        pip3 install -r requirements/onewire.txt
-
 .. attention::
 
     You need to have ``wire-1`` installed and configured for this module to work.


### PR DESCRIPTION
During the changes in #49 requirements were added to MQTT and removed from OneWire but the documentation was not updated to reflect that.

- Remove requirements notice from OneWire page.
- Add requirements notice to MQTT page.

This was discovered in #120